### PR TITLE
bumped versions

### DIFF
--- a/.github/workflows/atmos-terraform-apply.yaml
+++ b/.github/workflows/atmos-terraform-apply.yaml
@@ -48,8 +48,7 @@ jobs:
       - uses: unfor19/install-aws-cli-action@v1
 
       - name: Apply Atmos Component
-        #uses: cloudposse/github-action-atmos-terraform-apply@v4
-        uses: cloudposse/github-action-atmos-terraform-apply@feat/optional-plan-storage
+        uses: cloudposse/github-action-atmos-terraform-apply@v4
         with:
           # Atmos Pro args
           component: ${{ inputs.component }}

--- a/.github/workflows/atmos-terraform-plan.yaml
+++ b/.github/workflows/atmos-terraform-plan.yaml
@@ -40,8 +40,7 @@ jobs:
       - uses: unfor19/install-aws-cli-action@v1
 
       - name: Plan Atmos Component
-        #uses: cloudposse/github-action-atmos-terraform-plan@v5
-        uses: cloudposse/github-action-atmos-terraform-plan@feat/optional-plan-storage
+        uses: cloudposse/github-action-atmos-terraform-plan@v5
         with:
           # Atmos Pro args
           component: ${{ inputs.component }}


### PR DESCRIPTION
## what

- Point both github actions for Atmos back to the release

## why

- The feature is now published

## ref

- https://github.com/cloudposse/github-action-atmos-terraform-plan/pull/107
- https://github.com/cloudposse/github-action-atmos-terraform-apply/pull/74